### PR TITLE
DEV-8932: add lock concept to hub to allow staged shutdowns.  grab and release lock for SQS blocking packet long poll. restore old bandaid fix to add visibility timeout on restored SQS packets

### DIFF
--- a/kombu/asynchronous/hub.py
+++ b/kombu/asynchronous/hub.py
@@ -101,6 +101,7 @@ class Hub:
         self.propagate_errors = ()
 
         self._create_poller()
+        self.locks = set()
 
     @property
     def poller(self):
@@ -288,6 +289,15 @@ class Hub:
         logger.error(
             'Callback %r raised exception: %r', callback, exc, exc_info=1,
         )
+
+    def add_lock(self, lock):
+        self.locks.add(lock)
+
+    def remove_lock(self, lock):
+        self.locks.remove(lock)
+
+    def is_shutdown_ready(self):
+        return not self.locks
 
     def create_loop(self,
                     generator=generator, sleep=sleep, min=min, next=next,

--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -490,7 +490,7 @@ class Channel(virtual.Channel):
             c.change_message_visibility(
                 QueueUrl=q_url,
                 ReceiptHandle=message['properties']['delivery_tag'],
-                VisibilityTimeout=self.wait_time_seconds
+                VisibilityTimeout=0,
             )
         else:
             c.send_message(**kwargs)
@@ -623,11 +623,16 @@ class Channel(virtual.Channel):
     def _loop1(self, queue, _=None):
         self.hub.call_soon(self._schedule_queue, queue)
 
+    def _get_bulk_async_cb(self, queue, _=None):
+        self.hub.remove_lock(f"SQS-POLL-{queue}")
+        self._loop1(queue)
+
     def _schedule_queue(self, queue):
         if queue in self._active_queues:
             if self.qos.can_consume():
+                self.hub.add_lock(f"SQS-POLL-{queue}")
                 self._get_bulk_async(
-                    queue, callback=promise(self._loop1, (queue,)),
+                    queue, callback=promise(self._get_bulk_async_cb, (queue,)),
                 )
             else:
                 self._loop1(queue)

--- a/t/unit/transport/test_SQS.py
+++ b/t/unit/transport/test_SQS.py
@@ -620,7 +620,7 @@ class test_Channel:
         self.channel._put(self.producer.routing_key, message)
         self.sqs_conn_mock.change_message_visibility.assert_called_once_with(
             QueueUrl='https://sqs.us-east-1.amazonaws.com/xxx/unittest',
-            ReceiptHandle='test_message_id', VisibilityTimeout=10)
+            ReceiptHandle='test_message_id', VisibilityTimeout=0)
 
     def test_put_and_get_bulk(self):
         # With QoS.prefetch_count = 0


### PR DESCRIPTION
#patch#

This is a different approach to fix this issue https://github.com/celery/celery/issues/8875
and more specifically this PR https://github.com/celery/kombu/pull/2049

There will be a companion celery PR to ensure the hub.is_shutdown_ready() before the celery asyncloop is stopped during warm shutdown - https://github.com/carium-inc/celery/pull/1

# Changelog
* DEV-8932: add lock concept to hub to allow staged shutdowns. grab and release lock for SQS blocking packet long poll. restore old bandaid fix to add visibility timeout on restored SQS packets