### PR TITLE
DEV-9004: SQS: add basic_cancel lock timeout

### DIFF
--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -147,6 +147,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from json import JSONDecodeError
 from queue import Empty
+from time import monotonic
 from typing import Any
 
 from botocore.client import Config
@@ -341,9 +342,23 @@ class Channel(virtual.Channel):
     def basic_cancel(self, consumer_tag):
         if consumer_tag in self._consumers:
             queue = self._tag_to_queue[consumer_tag]
+            BASIC_CANCEL_LOCK_TIMEOUT = 30  # MAX SQS long polling time is 20 seconds, so we wait a bit longer than that to be safe.
+            wait_started = monotonic()
+            elapsed_wait = 0.0
             logger.info(f"SQS.Channel.basic_cancel:{queue}")
             while not self._aquire_lock(queue):
-                logger.info(f"SQS.Channel.basic_cancel:{queue}:wait")
+                current_time = monotonic()
+                elapsed_wait = current_time - wait_started
+                if elapsed_wait >= BASIC_CANCEL_LOCK_TIMEOUT:
+                    logger.warning(
+                        f"SQS.Channel.basic_cancel:{queue}:timeout:"
+                        f"{elapsed_wait:.2f}/{BASIC_CANCEL_LOCK_TIMEOUT}s"
+                    )
+                    break
+                logger.info(
+                    f"SQS.Channel.basic_cancel:{queue}:wait:"
+                    f"{elapsed_wait:.2f}/{BASIC_CANCEL_LOCK_TIMEOUT}s"
+                )
                 next(self.hub.loop)
             logger.info(f"SQS.Channel.basic_cancel:{queue}:ready")
             self._noack_queues.discard(queue)

--- a/t/unit/transport/test_SQS.py
+++ b/t/unit/transport/test_SQS.py
@@ -690,6 +690,26 @@ class test_Channel:
             'query': {'MessageSystemAttributeName.1': 'ApproximateReceiveCount'},
         }
 
+    def test_basic_cancel_gives_up_lock_after_timeout(self):
+        self.channel._aquire_lock = Mock(return_value=False)
+        self.channel.hub = Mock(loop=iter(()))
+
+        with patch('kombu.transport.SQS.monotonic', side_effect=[0, 31]):
+            self.channel.basic_cancel('unittest')
+
+        assert self.channel._aquire_lock.call_count == 1
+        assert 'unittest' not in self.channel._consumers
+
+    def test_basic_cancel_waits_for_lock_then_succeeds(self):
+        self.channel._aquire_lock = Mock(side_effect=[False, True])
+        self.channel.hub = Mock(loop=iter([None]))
+
+        with patch('kombu.transport.SQS.monotonic', side_effect=[0, 1]):
+            self.channel.basic_cancel('unittest')
+
+        assert self.channel._aquire_lock.call_count == 2
+        assert 'unittest' not in self.channel._consumers
+
     @pytest.mark.parametrize('fetch_attributes,expected', [
         # as a list for backwards compatibility
         (


### PR DESCRIPTION
#patch#

In the case there is some exception in the async thread, the SQS lock would not be released, and the basic_cancel would loop forever without some timeout.

# Changelog
* DEV-9004: SQS: add basic_cancel lock timeout