### PR TITLE
DEV-9085: Apply TIMEOUT/CONNECTTIMEOUT to pycurl handles to prevent stale connections

### DIFF
--- a/kombu/asynchronous/aws/connection.py
+++ b/kombu/asynchronous/aws/connection.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from email import message_from_bytes
 from email.mime.message import MIMEMessage
 
@@ -9,6 +10,8 @@ from vine import promise, transform
 
 from kombu.asynchronous.aws.ext import AWSRequest, get_cert_path, get_response
 from kombu.asynchronous.http import Headers, Request, get_client
+
+logger = logging.getLogger(__name__)
 
 
 def message_from_headers(hdr):
@@ -132,12 +135,17 @@ class AsyncHTTPSConnection:
 class AsyncConnection:
     """Async AWS Connection."""
 
-    def __init__(self, sqs_connection, http_client=None, **kwargs):
+    def __init__(self, sqs_connection, http_client=None,
+                 request_timeout=None, **kwargs):
         self.sqs_connection = sqs_connection
         self._httpclient = http_client or get_client()
+        self._request_timeout = request_timeout
 
     def get_http_connection(self):
-        return AsyncHTTPSConnection(http_client=self._httpclient)
+        kwargs = {}
+        if self._request_timeout:
+            kwargs['timeout'] = self._request_timeout
+        return AsyncHTTPSConnection(http_client=self._httpclient, **kwargs)
 
     def _mexe(self, request, sender=None, callback=None):
         callback = callback or promise()
@@ -177,10 +185,11 @@ class AsyncAWSQueryConnection(AsyncConnection):
     )
 
     def __init__(self, sqs_connection, http_client=None,
-                 http_client_params=None, **kwargs):
+                 http_client_params=None, request_timeout=None, **kwargs):
         if not http_client_params:
             http_client_params = {}
         super().__init__(sqs_connection, http_client,
+                         request_timeout=request_timeout,
                          **http_client_params)
 
     def make_request(self, operation, params_, path, verb, callback=None, protocol_params=None):
@@ -247,6 +256,11 @@ class AsyncAWSQueryConnection(AsyncConnection):
             # When the server returns a timeout or 50X server error,
             # the response is interpreted as an empty list.
             # This prevents hanging the Celery worker.
+            logger.warning(
+                'Async AWS request failed (status %s): %s. '
+                'Treating as empty response.',
+                response.status, getattr(response, 'error', ''),
+            )
             return []
         else:
             raise self._for_status(response, response.read())

--- a/kombu/asynchronous/http/curl.py
+++ b/kombu/asynchronous/http/curl.py
@@ -197,6 +197,15 @@ class CurlClient(BaseClient):
         setopt = curl.setopt
         setopt(_pycurl.URL, bytes_to_str(request.url))
 
+        # Apply timeouts to prevent curl handles from hanging indefinitely
+        # on dead TCP connections (e.g., NAT gateway drops, k8s pod evictions).
+        connect_timeout = getattr(request, 'connect_timeout', None)
+        request_timeout = getattr(request, 'request_timeout', None)
+        if connect_timeout and isinstance(connect_timeout, (int, float)):
+            setopt(_pycurl.CONNECTTIMEOUT_MS, int(connect_timeout * 1000))
+        if request_timeout and isinstance(request_timeout, (int, float)):
+            setopt(_pycurl.TIMEOUT_MS, int(request_timeout * 1000))
+
         # see tornado curl client
         request.headers.setdefault('Expect', '')
         request.headers.setdefault('Pragma', '')

--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -264,6 +264,7 @@ class Channel(virtual.Channel):
     default_region = 'us-east-1'
     default_visibility_timeout = 1800  # 30 minutes.
     default_wait_time_seconds = 10  # up to 20 seconds max
+    default_request_timeout_margin = 30  # extra seconds beyond wait_time
     domain_format = 'kombu%(vhost)s'
     _asynsqs = None
     _predefined_queue_async_clients = {}  # A client for each predefined queue
@@ -895,7 +896,8 @@ class Channel(virtual.Channel):
                     sqs_connection=self.sqs(queue=queue),
                     region=q.get('region', self.region),
                     message_system_attribute_names=message_system_attribute_names,
-                    message_attribute_names=message_attribute_names
+                    message_attribute_names=message_attribute_names,
+                    request_timeout=self.request_timeout,
             )
             return c
 
@@ -906,7 +908,8 @@ class Channel(virtual.Channel):
             sqs_connection=self.sqs(queue=queue),
             region=self.region,
             message_system_attribute_names=message_system_attribute_names,
-            message_attribute_names=message_attribute_names
+            message_attribute_names=message_attribute_names,
+            request_timeout=self.request_timeout,
         )
         return c
 
@@ -972,6 +975,22 @@ class Channel(virtual.Channel):
     def wait_time_seconds(self) -> int:
         return self.transport_options.get('wait_time_seconds',
                                           self.default_wait_time_seconds)
+
+    @cached_property
+    def request_timeout(self) -> float:
+        """Total HTTP request timeout for SQS long-poll requests.
+
+        Defaults to ``wait_time_seconds + default_request_timeout_margin``
+        (e.g., 10 + 30 = 40 seconds).  Must be greater than
+        wait_time_seconds to allow the long-poll to complete plus
+        network overhead.
+
+        Override via the ``request_timeout`` transport option (seconds).
+        """
+        return self.transport_options.get(
+            'request_timeout',
+            self.wait_time_seconds + self.default_request_timeout_margin
+        )
 
     @cached_property
     def sqs_base64_encoding(self):

--- a/t/unit/asynchronous/aws/test_connection.py
+++ b/t/unit/asynchronous/aws/test_connection.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from contextlib import contextmanager
 from io import StringIO
 from unittest.mock import Mock
@@ -257,18 +258,23 @@ class test_AsyncAWSQueryConnection(AWSCase):
         AsyncAWSQueryConnection.STATUS_CODE_SERVICE_UNAVAILABLE_ERROR,
         AsyncAWSQueryConnection.STATUS_CODE_GATEWAY_TIMEOUT
     ])
-    def test_on_list_ready_error_response(self, error_status_code):
+    def test_on_list_ready_error_response(self, error_status_code, caplog):
         mocked_response_error = self.Response(
             error_status_code,
             "error_status_code"
         )
-        result = self.x._on_list_ready(
-            "parent",
-            "markers",
-            "operation",
-            mocked_response_error
-        )
+        with caplog.at_level(logging.WARNING):
+            result = self.x._on_list_ready(
+                "parent",
+                "markers",
+                "operation",
+                mocked_response_error
+            )
         assert result == []
+        assert len(caplog.records) == 1
+        record = caplog.records[0]
+        assert 'Async AWS request failed' in record.message
+        assert str(error_status_code) in record.message
 
     def Response(self, status, body):
         r = Mock(name='response')


### PR DESCRIPTION
## Problem

Celery workers using SQS transport silently stop processing tasks. The pycurl async HTTP client never applied timeout settings to curl handles. A silently dropped TCP connection (common in k8s with NAT gateways) causes pycurl to wait indefinitely, killing the SQS scheduling loop permanently with zero errors or tracebacks.

## Root Cause

`CurlClient._setup_request` never set `TIMEOUT` or `CONNECTTIMEOUT` on curl handles, despite the `Request` object carrying these values. Without handle-level timeouts, pycurl cannot detect a dead connection — `info_read()` never reports the handle as completed, the callback never fires, and the scheduling loop (`_loop1` → `_schedule_queue` → `_get_bulk_async_cb`) dies forever.

## Fix

- Apply `CONNECTTIMEOUT_MS` and `TIMEOUT_MS` in `CurlClient._setup_request`
- Thread `request_timeout` from SQS Channel (`wait_time_seconds + 30s` margin) through `AsyncSQSConnection` → `AsyncConnection` → the `Request`
- Configurable via `transport_options['request_timeout']`

When a dead connection times out, pycurl reports it as a failed handle (code=599). The existing `_on_list_ready` handler already treats 599 as an empty response, so the callback chain fires normally and the scheduling loop continues.

## Testing

All 1337 unit tests pass (1 pre-existing region test deselected due to local AWS config).